### PR TITLE
Shrinking operator image and cutting build time by half

### DIFF
--- a/.ci/kind.yml
+++ b/.ci/kind.yml
@@ -4,5 +4,5 @@ nodes:
 - role: control-plane
 - role: worker
 - role: worker
-- role: worker
-- role: worker
+# - role: worker
+# - role: worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7.5-slim-buster
 ADD Pipfile /src/Pipfile
 ADD Pipfile.lock /src/Pipfile.lock
 ADD handlers.py /src/handlers.py


### PR DESCRIPTION
Switching to `python:3.7.5-slim-buster` (may consider `alpine` later, there are some libraries that need wheels and hence need to be compiled to use `musl` in `alpine` images). Also moving from 4 to 2 workers in the `kind` cluster (plus control plane)